### PR TITLE
fix: document ability to update expires_at on patch /tokens endpoint

### DIFF
--- a/docs/api/tokens/tokens.mdx
+++ b/docs/api/tokens/tokens.mdx
@@ -213,7 +213,7 @@ func main() {
 | `search_indexes`         | false    | _array_               | `null`                                                    | Array of [expressions](/docs/expressions/search-indexes) used to generate indexes to be able to search against.                                                                              |
 | `fingerprint_expression` | false    | _string_              | <code>{{ data &#124; stringify }}</code>                  | [Expressions](/docs/expressions/fingerprints) used to fingerprint your token.                                                                                                                |
 | `deduplicate_token`      | false    | _bool_                | `null`                                                    | Whether the token is deduplicated on creation.                                                                                                                                               |
-| `expires_at`             | false    | _string_              | `null`                                                    | ISO8601 compatible Token expiration DateTime. See [Token Expiration](#token-expiration) for more details.                                                                                    |
+| `expires_at`             | false    | _string_              | `null`                                                    | ISO8601 compatible Token expiration DateTime. See [Token Expiration](/docs/api/tokens/#token-expiration) for more details.                                                                   |
 
 <Alert type={Alerts.WARNING}>
   Never reveal sensitive information in the <code>id</code> of your token. See
@@ -732,6 +732,7 @@ func main() {
 | `search_indexes`         | false    | _array_               | Replace                                                                                | Array of [expressions](/docs/expressions/search-indexes) used to generate indexes to be able to search against.                                                                              |
 | `fingerprint_expression` | false    | _string_              | Replace                                                                                | [Expressions](/docs/expressions/fingerprints) used to fingerprint your token.                                                                                                                |
 | `deduplicate_token`      | false    | _bool_                | Replace                                                                                | Whether the token is deduplicated on creation.                                                                                                                                               |
+| `expires_at`             | false    | _string_              | Replace                                                                                | ISO8601 compatible Token expiration DateTime. See [Token Expiration](/docs/api/tokens/#token-expiration) for more details.                                                                   |
 
 ### Response
 
@@ -901,7 +902,7 @@ Returns [an error](/docs/api/errors) if the token failed to delete.
 | `modified_at`            | _date_                | (Optional) Last modified date of the token in ISO 8601 format                                                                                                                                |
 | `search_indexes`         | _array_               | (Optional) Array of search index [expressions](/docs/expressions/search-indexes) used when creating the token.                                                                               |
 | `fingerprint_expression` | _string_              | (Optional) An [expression](/docs/expressions/fingerprints) defining the value to fingerprint when creating the token.                                                                        |
-| `expires_at`             | _string_              | (Optional) The [token expiration](#token-expiration) date.                                                                                                                                   |
+| `expires_at`             | _string_              | (Optional) The [token expiration](/docs/api/tokens/#token-expiration) date.                                                                                                                  |
 
 ### Token Data Validations
 
@@ -924,7 +925,7 @@ Returns [an error](/docs/api/errors) if the token failed to delete.
 ### Token Expiration
 
 By default a created token will not expire, however, users can optionally set the `expires_at` property with an ISO8601 `DateTime` when creating a token to determine its expiration date.
-An expired token is **deleted** from the tenant up to **1 hour** after it's expiration time.
+An expired token is **deleted** from the tenant up to **1 hour** after its expiration time.
 
 ### Expiration Date Formats
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

Document ability to update `expires_at` on `PATCH /tokens` endpoint. Also change some relative paths / links to absolute links according to this [Slack thread in #Engineering](https://basistheory.slack.com/archives/C01HVEKV3LP/p1673029045016989).

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
