### PR TITLE
Update example Gradle repository

### DIFF
--- a/docs/sdks/server-side/java.mdx
+++ b/docs/sdks/server-side/java.mdx
@@ -38,7 +38,7 @@ Add this dependency to your project's build file:
   }
 
   dependencies {
-     implementation 'com.basistheory:basistheory-java:[version]'
+     implementation 'com.github.Basis-Theory:basistheory-java:[version]'
   }
 ```
 


### PR DESCRIPTION
## Description

Noticed while following the SDK docs the Gradle example appears to have the incorrect repsitory provided, updated as per that provided on https://www.jitpack.io/#Basis-Theory/basistheory-java/0.4.0