### PR TITLE
feat: add ios enableCopy docs

### DIFF
--- a/docs/sdks/mobile/ios/options.mdx
+++ b/docs/sdks/mobile/ios/options.mdx
@@ -120,3 +120,24 @@ textElementUITextField.setConfig(options: TextElementOptions(mask: phoneMask, tr
   Validation is performed on the transformed value when <a href="/docs/sdks/mobile/ios/options#transform">transform</a> is set. Had a transform not been set above removing the parentheses and dashes, the validation would be performed on a
   value like <code>(123)456-7890</code>. The proper <code>NSRegularExpression</code> pattern for that would be <code>"^\\(\\d&#123;3&#125;\\)\\d&#123;3&#125;-\\d&#123;4&#125;$"</code>
 </Alert>
+
+## Enable Copy
+
+Enable Copy allows users to copy the value of the Element to their clipboard without the implementer touching the data.
+
+A copy icon is added to the right side of the input field through the `enableCopy` attribute. The icon can be tapped to copy the Element value to the clipboard.
+The icon will change to a checkmark when the value has been copied and change back to the copy icon after a brief moment.
+
+```swift showLineNumbers
+textElementUITextField.setConfig(options: TextElementOptions(enableCopy: true))
+```
+
+### Copy Icon Color
+
+The color of the icon can be changed from the default iOS blue through the `copyIconColor` attribute. 
+That attribute takes in a `UIColor` object. For example, to change the color to red, you can do the following:
+
+```swift showLineNumbers
+textElementUITextField.setConfig(options: TextElementOptions(enableCopy: true, copyIconColor: UIColor.red))
+```
+

--- a/docs/sdks/mobile/ios/types.mdx
+++ b/docs/sdks/mobile/ios/types.mdx
@@ -53,11 +53,13 @@ The `TextElementUITextField` extends the native `UITextField` from UIKit, so all
 
 The following additional properties are supported when programmatically interacting with a `TextElementUITextField`:
 
-| Name       | Type                                                                                                                                         |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| validation | No default [validation](/docs/sdks/mobile/ios/options#validation). [Validation](/docs/sdks/mobile/ios/options#validation) can be overridden. |
-| mask       | No default [mask](/docs/sdks/mobile/ios/options#mask). [Mask](/docs/sdks/mobile/ios/options#mask) can be overridden.                         |
-| transform  | No default [transform](/docs/sdks/mobile/ios/options#transform). [Transform](/docs/sdks/mobile/ios/options#transform) can be overridden.     |
+| Name          | Type                                                                                                                                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| validation    | No default [validation](/docs/sdks/mobile/ios/options#validation). [Validation](/docs/sdks/mobile/ios/options#validation) can be overridden. |
+| mask          | No default [mask](/docs/sdks/mobile/ios/options#mask). [Mask](/docs/sdks/mobile/ios/options#mask) can be overridden.                         |
+| transform     | No default [transform](/docs/sdks/mobile/ios/options#transform). [Transform](/docs/sdks/mobile/ios/options#transform) can be overridden.     |
+| enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                            |
+| copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                              |
 
 <Alert>
   <code>TextElementUITextField</code> extends the native iOS <a href="https://developer.apple.com/documentation/uikit/uitextfield">UITextField</a> from UIKit, so all standard properties and attributes
@@ -126,6 +128,8 @@ By default, this element is configured with:
 | validation    | Input must be Luhn valid and be an acceptable length for the card brand.                                                                                  |
 | mask          | The [mask](/docs/sdks/mobile/ios/options#mask) changes depending on the card brand identified for this input according to the [card brand](#card-brands). |
 | transform     | The [transform](/docs/sdks/mobile/ios/options#transform) removes all spaces set by the [mask](/docs/sdks/mobile/ios/options#mask) before tokenization.    |
+| enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                                         |
+| copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                                           |
 
 ### Card Brands
 
@@ -206,6 +210,8 @@ By default, this element is configured with:
 | validation    | Input must be the current month and year or later.                                                                                   |
 | mask          | The [mask](/docs/sdks/mobile/ios/options#mask) is two digits followed by a forward slash followed by two more digits (eg. `MM/YY` ). |
 | transform     | No default [transform](/docs/sdks/mobile/ios/options#transform).                                                                     |
+| enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                    |
+| copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                      |
 
 #### Month and Year
 
@@ -296,6 +302,8 @@ By default, this element is configured with:
 | validation    | No default validation. Always valid in [ElementEvent](/docs/sdks/mobile/ios/events#elementevent).                                                                                                                                                                                                                                                 |
 | mask          | If not associated with a `CardNumberUITextField`, the [mask](/docs/sdks/mobile/ios/options#mask) is a 4 digit number. If it is, the [mask](/docs/sdks/mobile/ios/options#mask) changes depending on the [card brand](#card-brands) identified by the `CardNumberUITextField`. Refer to the [section below](#associating-a-cardnumberuitextfield). |
 | transform     | No default [transform](/docs/sdks/mobile/ios/options#transform).                                                                                                                                                                                                                                                                                  |
+| enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                                                                                                                                                                                                                                 |
+| copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                                                                                                                                                                                                                                   |
 
 ### Associating a CardNumberUITextField
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds docs for the enableCopy and copyIconColor attributes in iOS.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/8c8d22e0-7a10-487d-b7d4-165792856cd7)

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/373fbfe4-e74e-4e44-834d-026997d3ade2)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
