### PR TITLE
feat: add ios getValueType docs

### DIFF
--- a/docs/sdks/mobile/ios/options.mdx
+++ b/docs/sdks/mobile/ios/options.mdx
@@ -143,8 +143,8 @@ textElementUITextField.setConfig(options: TextElementOptions(enableCopy: true, c
 
 ## Get Value Type
 
-The `getValueType` attribute allows you to specify the type of value that will be returned when the Element is tokenized.
-If none is specified, the value will be returned as a `String`. The following types are supported:
+The `getValueType` attribute allows you to specify the type of value that will be rendered when the Element is sent to the API.
+If none is specified, the value will be rendered as a `String`. The following types are supported:
 
 | `getValueType` Value  | Type     |
 | --------------------- | -------- |

--- a/docs/sdks/mobile/ios/options.mdx
+++ b/docs/sdks/mobile/ios/options.mdx
@@ -141,3 +141,18 @@ That attribute takes in a `UIColor` object. For example, to change the color to 
 textElementUITextField.setConfig(options: TextElementOptions(enableCopy: true, copyIconColor: UIColor.red))
 ```
 
+## Get Value Type
+
+The `getValueType` attribute allows you to specify the type of value that will be returned when the Element is tokenized.
+If none is specified, the value will be returned as a `String`. The following types are supported:
+
+| `getValueType` Value  | Type     |
+| --------------------- | -------- |
+| `.string`             | `String` |
+| `.int`                | `Int`    |
+| `.double`             | `Double` |
+| `.bool`               | `Bool`   |
+
+```swift showLineNumbers
+textElementUITextField.setConfig(options: TextElementOptions(getValueType: .int))
+```

--- a/docs/sdks/mobile/ios/types.mdx
+++ b/docs/sdks/mobile/ios/types.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Types
 ---
 
-import { Alert } from "@site/src/components/shared/Alert";
+import { Alert, Alerts } from "@site/src/components/shared/Alert";
 import Link from "@docusaurus/Link";
 
 # iOS Element Types
@@ -60,6 +60,7 @@ The following additional properties are supported when programmatically interact
 | transform     | No default [transform](/docs/sdks/mobile/ios/options#transform). [Transform](/docs/sdks/mobile/ios/options#transform) can be overridden.     |
 | enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                            |
 | copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                              |
+| getValueType  | [getValueType](/docs/sdks/mobile/ios/options#get-value-type) defaults to `.string` and can be overriden.                                     |
 
 <Alert>
   <code>TextElementUITextField</code> extends the native iOS <a href="https://developer.apple.com/documentation/uikit/uitextfield">UITextField</a> from UIKit, so all standard properties and attributes
@@ -130,6 +131,7 @@ By default, this element is configured with:
 | transform     | The [transform](/docs/sdks/mobile/ios/options#transform) removes all spaces set by the [mask](/docs/sdks/mobile/ios/options#mask) before tokenization.    |
 | enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                                         |
 | copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                                           |
+| getValueType  | [getValueType](/docs/sdks/mobile/ios/options#get-value-type) defaults to `.string` and can be overriden.                                                  |
 
 ### Card Brands
 
@@ -212,6 +214,7 @@ By default, this element is configured with:
 | transform     | No default [transform](/docs/sdks/mobile/ios/options#transform).                                                                     |
 | enableCopy    | [enableCopy](/docs/sdks/mobile/ios/options#enable-copy) defaults to `false` and can be overriden.                                    |
 | copyIconColor | [copyIconColor](/docs/sdks/mobile/ios/options#copy-icon-color) defaults to `UIColor.blue` and can be overriden.                      |
+| getValueType  | [getValueType](/docs/sdks/mobile/ios/options#get-value-type) defaults to `.string` and can be overriden.                             |
 
 #### Month and Year
 
@@ -228,6 +231,12 @@ let body: [String: Any] = [
   "type": "card"
 ]
 ```
+
+<Alert type={Alerts.WARNING}>
+  Before SDK version <code>3.0.0</code> the <code>month()</code> and <code>year()</code> methods rendered as <code>String</code> when sending the value to the API.
+  As of version <code>3.0.0</code>, these methods now render as <code>Int</code> when sending the value to the API.
+</Alert>
+
 
 #### Format
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds docs for getValueType for iOS SDK.
- Adds warning about changing value type to `Int` for `month()` and `year()` methods in exp date element (iOS).

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/56be1174-bdbb-40fc-b78e-dcea9437a54a)

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/aa0c2754-93b7-453a-99e1-464f672c2f53)

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/973ddc7d-6b86-49b7-aa7b-ca256532f2e3)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
