### PR TITLE
feat: add android getValueType docs

### DIFF
--- a/docs/sdks/mobile/android/options.mdx
+++ b/docs/sdks/mobile/android/options.mdx
@@ -121,6 +121,24 @@ also whether data entered into an Element will be displayed or hidden (replaced 
 | `TEXT_PASSWORD`   | `textPassword`      | Alphanumeric  | Hidden         |
 | `NUMBER_PASSWORD` | `numberPassword`    | Numeric       | Hidden         |
 
+
+## Get Value Type
+
+The `getValueType` attribute allows you to specify the type of value that will be rendered when the Element is sent to the API.
+If none is specified, the value will be rendered as a `String`. The following types are supported:
+
+| `getValueType` Value        | Type     |
+| --------------------------- | -------- |
+| `ElementValueType.STRING`   | `String` |
+| `ElementValueType.INTEGER`  | `Int`    |
+| `ElementValueType.DOUBLE`   | `Double` |
+| `ElementValueType.BOOLEAN`  | `Boolean`   |
+
+```kotlin showLineNumbers
+element.getValueType = ElementValueType.INTEGER
+```
+
+
 ## Styling
 
 Elements have been designed to take advantage of all pre-existing native layout properties

--- a/docs/sdks/mobile/android/types.mdx
+++ b/docs/sdks/mobile/android/types.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Types
 ---
 
-import { Alert } from "@site/src/components/shared/Alert";
+import { Alert, Alerts } from "@site/src/components/shared/Alert";
 import Link from "@docusaurus/Link";
 import CardBrands from "@site/docs/sdks/_card-brands.mdx";
 
@@ -59,6 +59,7 @@ The following additional properties are supported when programmatically interact
 | transform           | `ElementTransform` | Transforms the value of this Element prior to tokenization. See the [Transform](/docs/sdks/mobile/android/options#transform) options for details.                                                                                                  |
 | validator           | `ElementValidator` | Validates the value of this Element. See the [Validator](/docs/sdks/mobile/android/options#validator) options for details.                                                                                                                         |
 | gravity             | `Int`              | The [Gravity](https://developer.android.com/reference/android/view/Gravity) value to apply to the text within the element.                                                                                                                         |                                                                                                                                                                                    |
+| getValueType        | `ElementValueType` | The [value type](/docs/sdks/mobile/android/options#get-value-type) for which the element value is rendered to before being sent to the API.                                                                                                            |    
 
 #### Methods
 
@@ -243,6 +244,11 @@ val tokenizeResponse = bt.tokenize(object {
 The `month()` and `year()` functions expose a reference object that can only be resolved back to the
 original values by the `BasisTheoryElements` service when tokenizing. These methods do not
 provide your application with direct access to the underlying plaintext values.
+
+<Alert type={Alerts.WARNING}>
+  Before SDK version <code>3.0.0</code> the <code>month()</code> and <code>year()</code> methods rendered as <code>String</code> when sending the value to the API.
+  As of version <code>3.0.0</code>, these methods now render as <code>Int</code> when sending the value to the API.
+</Alert>
 
 Also, `format(dateFormat: String)` allows you to customize card expiration dates. It implements Java's [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html), so all date formats supported by it are also available.
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

Adds docs for `getValueType` for Android SDK.
Adds warning about changing value type to `Int` for `month()` and `year()` methods in exp date element (Android).

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/38f5a314-1685-4944-8728-3536313eea6a)

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/fa5b9e78-533f-4e3c-9da3-f859c7a27057)

![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/9054729/5a8db33f-9207-45d9-b3b8-67c1b6f41bd9)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
