### PR TITLE
fix: add step for enforcing https

### DIFF
--- a/docs/concepts/what-is-the-proxy.mdx
+++ b/docs/concepts/what-is-the-proxy.mdx
@@ -77,7 +77,8 @@ All you need to do is the following:
 2. Create a new Pre-Configured Proxy instance
 3. Contact Basis Theory support to inform us of your desired hostname and Proxy id
 4. Create a CNAME record pointing your custom hostname to `api.btproxy.cloud`
-5. Basis Theory support will inform you of the TXT record(s) to create to validate domain ownership
+5. Enforce HTTPS on that CNAME record, by turning on (permanent) auto-redirects or creating custom rules (e.g. [Cloudflare](https://developers.cloudflare.com/ssl/edge-certificates/additional-options/always-use-https/))
+6. Basis Theory support will inform you of the TXT record(s) to create to validate domain ownership
 
 <Alert>If you're ready to get started with white labeling your Basis Theory proxies, <a href="https://basistheory.com/contact"> please reach out</a>.</Alert>
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

Custom hostnames only work in HTTPS. To avoid silly errors, customers need to enforce the protocol.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
