### PR TITLE
Add documentation for ephemeral proxy disable

### DIFF
--- a/docs/api/proxies/ephemeral-proxy.mdx
+++ b/docs/api/proxies/ephemeral-proxy.mdx
@@ -7,6 +7,7 @@ import { Permission } from "@site/src/components/shared/Permission";
 import ReservedHeaders from "./_reserved_headers.mdx";
 import CustomHeaders from "./_custom_headers.mdx";
 import { Enterprise } from "@site/src/components/shared/Enterprise";
+import { Alert } from "@site/src/components/shared/Alert";
 
 # Ephemeral Proxy
 
@@ -14,6 +15,8 @@ The Basis Theory Proxy can be used to share tokenized data with trusted third pa
 Some outbound proxy requests simply need to [detokenize](/docs/expressions/detokenization) some tokens in the request and forward
 the plaintext data to a destination API over HTTP. Ephemeral proxy requests are a good fit for this use case,
 as they don't require any up-front setup, and all configuration is self-contained within the proxy request.
+
+<Alert>Ephemeral proxies can be enabled or disable per tenant.</Alert>
 
 ## Invoke the Proxy
 

--- a/docs/api/proxies/ephemeral-proxy.mdx
+++ b/docs/api/proxies/ephemeral-proxy.mdx
@@ -16,7 +16,7 @@ Some outbound proxy requests simply need to [detokenize](/docs/expressions/detok
 the plaintext data to a destination API over HTTP. Ephemeral proxy requests are a good fit for this use case,
 as they don't require any up-front setup, and all configuration is self-contained within the proxy request.
 
-<Alert>Ephemeral proxies can be enabled or disable per tenant.</Alert>
+<Alert>Ephemeral proxies can be enabled or disabled per tenant.</Alert>
 
 ## Invoke the Proxy
 

--- a/docs/api/tenants/tenants.mdx
+++ b/docs/api/tenants/tenants.mdx
@@ -131,6 +131,7 @@ Returns a [Tenants](#tenant-object) for the provided `BT-API-KEY`. Returns [an e
   "name": "My Tenant",
   "settings": {
     "fingerprint_tokens": "false",
+    "disable_ephemeral_proxy": "false",
     "deduplicate_tokens": "false"
   },
   "created_by": "fb124bba-f90d-45f0-9a59-5edca27b3b4a",
@@ -167,6 +168,7 @@ curl "https://api.basistheory.com/tenants/self" \
     "name": "My Example Tenant",
     "settings": {
       "fingerprint_tokens": "true",
+      "disable_ephemeral_proxy": "true",
       "deduplicate_tokens": "true"
     }
   }'
@@ -184,6 +186,7 @@ const tenant = await bt.tenants.update({
   name: "My Example Tenant",
   settings: {
     fingerprint_tokens: "true",
+    disable_ephemeral_proxy: "true",
     deduplicate_tokens: "true",
   },
 });
@@ -203,6 +206,7 @@ var tenant = await client.UpdateAsync(new TenantUpdateRequest
   Settings = new Dictionary<string, string>
   {
     { "fingerprint_tokens", "true" },
+    { "disable_ephemeral_proxy", "true" },
     { "deduplicate_tokens", "true" }
   }
 });
@@ -267,6 +271,7 @@ func main() {
   updateTenantRequest := *basistheory.NewUpdateTenantRequest("My Example Tenant")
   updateTenantRequest.SetSettings(map[string]string{
     "fingerprint_tokens": "true",
+    "disable_ephemeral_proxy": "true",
     "deduplicate_tokens": "true",
   })
 
@@ -295,6 +300,7 @@ Returns a [tenant](#tenant-object) if the Tenant was updated. Returns [an error]
   "name": "My Example Tenant",
   "settings": {
     "fingerprint_tokens": "true",
+    "disable_ephemeral_proxy": "true",
     "deduplicate_tokens": "true"
   },
   "created_by": "fb124bba-f90d-45f0-9a59-5edca27b3b4a",
@@ -559,10 +565,11 @@ Returns a [Tenant Usage Report](#tenant-usage-report-object) for the provided `B
 
 ### Tenant Settings Object
 
-| Attribute            | Type     | Description                                                                                                                                                                                                                                                                                   |
-|----------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `fingerprint_tokens` | _string_ | (Bool) Whether all tokens will be fingerprinted using the [default fingerprint expression](/docs/api/tokens/token-types) for its token type. When disabled, fingerprinting can still be enabled per token by setting a [fingerprint expression](/docs/expressions/fingerprints) on the token. |
-| `deduplicate_tokens` | _string_ | (Bool) Whether tokens are [deduplicated](/docs/concepts/what-are-tokens#deduplication) on creation and updates                                                                                                                                                                                |
+| Attribute                 | Type     | Description                                                                                                                                                                                                                                                                                   |
+|---------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `fingerprint_tokens`      | _string_ | (Bool) Whether all tokens will be fingerprinted using the [default fingerprint expression](/docs/api/tokens/token-types) for its token type. When disabled, fingerprinting can still be enabled per token by setting a [fingerprint expression](/docs/expressions/fingerprints) on the token. |
+| `disable_ephemeral_proxy` | _string_ | (Bool) When `true`, [ephemeral proxies](/docs/api/proxies/ephemeral-proxy) will not be allowed for the tenant.                                                                                                                                                                                |
+| `deduplicate_tokens`      | _string_ | (Bool) Whether tokens are [deduplicated](/docs/concepts/what-are-tokens#deduplication) on creation and updates                                                                                                                                                                                |
 
 ## Tenant Usage Report Object
 

--- a/docs/api/tenants/tenants.mdx
+++ b/docs/api/tenants/tenants.mdx
@@ -122,7 +122,7 @@ func main() {
 
 ### Response
 
-Returns a [Tenants](#tenant-object) for the provided `BT-API-KEY`. Returns [an error](/docs/api/errors) if the Tenant could not be retrieved.
+Returns a [Tenant](#tenant-object) for the provided `BT-API-KEY`. Returns [an error](/docs/api/errors) if the Tenant could not be retrieved.
 
 ```json showLineNumbers
 {
@@ -557,7 +557,7 @@ Returns a [Tenant Usage Report](#tenant-usage-report-object) for the provided `B
 | `id`          | _uuid_                                     | Unique identifier of the Tenant                                                                      |
 | `owner_id`    | _uuid_                                     | The user ID which owns the Tenant                                                                    |
 | `name`        | _string_                                   | The name of the Tenant                                                                               |
-| `settings`    | [Tenant Settings](#tenant-settings-object) | The setting for the Tenant                                                                           |
+| `settings`    | [Tenant Settings](#tenant-settings-object) | The settings for the Tenant                                                                           |
 | `created_by`  | _uuid_                                     | (Optional) The ID of the user that created the Tenant                                                |
 | `created_at`  | _date_                                     | (Optional) Created date of the Tenant in ISO 8601 format                                             |
 | `modified_by` | _uuid_                                     | (Optional) The ID of the user or [Application](/docs/api/applications) that last modified the Tenant |


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Add small alert on the Ephemeral Proxy page indicating ephemeral proxies can be disabled.
- Add documentation in the TenantSettings object section on the Tenants page.
- Add `disable_ephemeral_proxy` attribute to code samples on Tenants page.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

https://developers.basistheory.com/docs/api/proxies/ephemeral-proxy
![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/1724894/9aa6f09b-9b05-4489-89cc-ecc1a8f9bb66)


https://developers.basistheory.com/docs/api/tenants/#tenant-settings-object
![image](https://github.com/Basis-Theory/developers.basistheory.com/assets/1724894/819cbcc2-c090-494e-86eb-45f8f2f1f86b)


- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
