### PR TITLE
feat: add timeout prop for 3ds start challenge

### DIFF
--- a/docs/guides/process/authenticate-with-3ds.mdx
+++ b/docs/guides/process/authenticate-with-3ds.mdx
@@ -459,6 +459,7 @@ If the `status` for the authentication response is `successful`, that means a fr
 If after authenticating a 3DS session, the authentication response `status` is set as `challenge`, that means that the customer needs to perform a challenge, like inputting a passcode, before getting the final 3DS authentication value.
 
 You can trigger the user challenge by calling the `startChallenge` method, which returns a `Promise` that will only be resolved once the user completes it.
+By default, `startChallenge` will time out and reject the `Promise` if the user does not complete the challenge within 60000ms (1 minute). This can be configured by passing the `timeout` property in the challenge object.
 
 ```typescript showLineNumbers
 import { BasisTheory3ds } from "@basis-theory/3ds-web";

--- a/docs/sdks/web/3ds/methods.mdx
+++ b/docs/sdks/web/3ds/methods.mdx
@@ -73,6 +73,7 @@ The `startChallenge` method takes in an object with the following attributes:
 | `sessionId` | true | _string_ | The created 3DS session id |
 | `threeDSVersion` | true | _string_ | The 3DS message version. Available from the [Authenticate](/docs/api/3ds/sessions#authenticate-session) endpoint response |
 | `windowSize` | false | _string_ | The code for the pre-configured window size. See [Challenge Window Sizes](#challenge-window-sizes) |
+| `timeout`| false | _number_ | The time in miliseconds to wait for challenge completion before considering it timed out. Defaults to 60000ms (1 minute) |
 
 ### Return
 The method returns a `Promise`, with the following attributes, that is only resolved once the customer completed or cancelled the challenge:


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `timeout` prop and information about it for 3DS `startChallenge`.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
