### PR TITLE
feat: Add Stripe example to google and apple pay docs

### DIFF
--- a/docs/guides/apple-pay/accept-payments.mdx
+++ b/docs/guides/apple-pay/accept-payments.mdx
@@ -362,6 +362,11 @@ curl 'https://api.basistheory.com/proxy' \
   </TabItem>
 
   <TabItem value="stripe" label="Stripe">
+  <Alert>
+  You may need to ask Stripe to enable Apple Pay for your account.
+  </Alert>
+
+  Please note that Stripe does not recognize network token parameters on creation of a payment methods.
 
   ```shell showlineNumbers title="Charge Payment method through a Proxy"
 curl 'https://api.basistheory.com/proxy'
@@ -384,13 +389,9 @@ curl 'https://api.basistheory.com/proxy'
   -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
   -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
   -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+  -d "payment_method_options[card][network_token][electronic_commerce_indicator]"={{token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.eci_indicator\" }}
   // highlight-end
   ```
-
-  You may need to ask Stripe to enable Apple Pay for your account.
-
-  Please note that Stripe does not recognize network token parameters on creation of a payment methods.
-
   </TabItem>
 </Tabs>
 

--- a/docs/guides/apple-pay/accept-payments.mdx
+++ b/docs/guides/apple-pay/accept-payments.mdx
@@ -329,7 +329,7 @@ We'll change our frontend application one last time to pass in the Token Intent 
 We'll set up and invoke the [ephemeral Proxy](/docs/api/proxies/ephemeral-proxy) on our backend.
 
 <Tabs className="bt-tabs" groupId="processor">
-  <TabItem value="javascript" label="Checkout">
+  <TabItem value="checkout" label="Checkout">
 
   ```shell showlineNumbers title="Charge Payment method through a Proxy"
 curl 'https://api.basistheory.com/proxy' \
@@ -360,9 +360,39 @@ curl 'https://api.basistheory.com/proxy' \
   [Checkout Payment Method Docs](https://www.checkout.com/docs/payments/add-payment-methods/apple-pay/api-only#Request_a_payment).
 
   </TabItem>
+
+  <TabItem value="stripe" label="Stripe">
+
+  ```shell showlineNumbers title="Charge Payment method through a Proxy"
+curl 'https://api.basistheory.com/proxy'
+  // highlight-start
+  -H 'BT-API-KEY: <PRIVATE_API_KEY>' \
+  -H 'BT-PROXY-URL: https://api.stripe.com/v1/payment_intents' \
+  -H 'Authorization: Bearer <STRIPE_AUTH_TOKEN>' \
+  // highlight-end
+  -d amount=1000 \
+  -d currency=usd \
+  -d "payment_method_types[]"=card \
+  -d confirm=true \
+  -d "payment_method_data[type]"=card \
+  -d "payment_method_data[card][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
+  -d "payment_method_data[card][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
+  -d "payment_method_data[card][last4]"={{token_intent: <TOKEN_INTENT_ID> | json: '$.data.number' | last4 }} \
+  -d "payment_method_data[card][network_token][number]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data.number\" }} \
+  -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
+  -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
+  -d "payment_method_data[card][network_token][tokenization_method]"=apple_pay \
+  -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+  ```
+
+  You may need to ask Stripe to enable Apple Pay for your account.
+
+  Please note that Stripe does not recognize network token parameters on creation of a payment methods.
+
+  </TabItem>
 </Tabs>
 
-<Alert>You are not restricted to only using Checkout. You can use any payment processor that accepts Apple Pay tokens.</Alert>
+<Alert>You are not restricted to only using Checkout or Stripe. You can use any payment processor that accepts Apple Pay tokens.</Alert>
 
 ## Testing
 

--- a/docs/guides/apple-pay/accept-payments.mdx
+++ b/docs/guides/apple-pay/accept-payments.mdx
@@ -363,10 +363,10 @@ curl 'https://api.basistheory.com/proxy' \
 
   <TabItem value="stripe" label="Stripe">
   <Alert>
-  You may need to ask Stripe to enable Apple Pay for your account.
+  You may need to ask Stripe to enable accepting decrypted Apple Pay in your account.
   </Alert>
 
-  Please note that Stripe does not recognize network token parameters on creation of a payment methods.
+  Please note that Stripe does not recognize network token parameters on creation of a payment method.
 
   ```shell showlineNumbers title="Charge Payment method through a Proxy"
 curl 'https://api.basistheory.com/proxy'
@@ -389,13 +389,13 @@ curl 'https://api.basistheory.com/proxy'
   -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
   -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
   -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
-  -d "payment_method_options[card][network_token][electronic_commerce_indicator]"={{token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.eci_indicator\" }}
+  -d "payment_method_options[card][network_token][electronic_commerce_indicator]"={{token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.eci_indicator\" | pad_left: 2, \"0\" }}
   // highlight-end
   ```
   </TabItem>
 </Tabs>
 
-<Alert>You are not restricted to only using Checkout or Stripe. You can use any payment processor that accepts Apple Pay tokens.</Alert>
+<Alert>You are not restricted to only using Checkout or Stripe. You can use any payment processor that accepts decrypted Apple Pay tokens.</Alert>
 
 ## Testing
 

--- a/docs/guides/apple-pay/accept-payments.mdx
+++ b/docs/guides/apple-pay/accept-payments.mdx
@@ -375,14 +375,16 @@ curl 'https://api.basistheory.com/proxy'
   -d "payment_method_types[]"=card \
   -d confirm=true \
   -d "payment_method_data[type]"=card \
+  -d "payment_method_data[card][network_token][tokenization_method]"=apple_pay \
+    // highlight-start
   -d "payment_method_data[card][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
   -d "payment_method_data[card][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
   -d "payment_method_data[card][last4]"={{token_intent: <TOKEN_INTENT_ID> | json: '$.data.number' | last4 }} \
   -d "payment_method_data[card][network_token][number]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data.number\" }} \
   -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
   -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
-  -d "payment_method_data[card][network_token][tokenization_method]"=apple_pay \
   -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+  // highlight-end
   ```
 
   You may need to ask Stripe to enable Apple Pay for your account.

--- a/docs/guides/google-pay/accept-payments.mdx
+++ b/docs/guides/google-pay/accept-payments.mdx
@@ -269,7 +269,7 @@ async function chargePayment(tokenIntentId) {
 We'll setup and invoke the [ephemeral Proxy](/docs/api/proxies/ephemeral-proxy) on our backend.
 
 <Tabs className="bt-tabs" groupId="processor">
-  <TabItem value="javascript" label="Checkout">
+  <TabItem value="checkout" label="Checkout">
 
   ```shell showlineNumbers title="Charge Payment method through a Proxy"
 curl 'https://api.basistheory.com/proxy' \

--- a/docs/guides/google-pay/accept-payments.mdx
+++ b/docs/guides/google-pay/accept-payments.mdx
@@ -331,14 +331,16 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
     -d "payment_method_types[]"=card \
     -d confirm=true \
     -d "payment_method_data[type]"=card \
+    -d "payment_method_data[card][network_token][tokenization_method]"=google_pay \
+    // highlight-start
     -d "payment_method_data[card][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
     -d "payment_method_data[card][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
     -d "payment_method_data[card][last4]"={{token_intent: <TOKEN_INTENT_ID> | json: '$.data.number' | last4 }} \
     -d "payment_method_data[card][network_token][number]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data.number\" }} \
     -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
     -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
-    -d "payment_method_data[card][network_token][tokenization_method]"=google_pay \
     -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+    // highlight-end
     ```
 
     You may need to ask Stripe to enable Google Pay for your account.

--- a/docs/guides/google-pay/accept-payments.mdx
+++ b/docs/guides/google-pay/accept-payments.mdx
@@ -319,7 +319,7 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
 
   <TabItem value="stripe" label="Stripe">
     <Alert>
-      You may need to ask Stripe to enable Google Pay for your account.
+      You may need to ask Stripe to enable accepting decrypted Google Pay in your account.
     </Alert>
     Please note that Stripe does not recognize network token parameters on creation of a payment methods.
 
@@ -361,7 +361,7 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
     </TabItem>
 </Tabs>
 
-<Alert>You are not restricted to only using Checkout or Stripe. You can use any payment processor that accepts Google Pay tokens.</Alert>
+<Alert>You are not restricted to only using Checkout or Stripe. You can use any payment processor that accepts decrypted Google Pay tokens.</Alert>
 
 ## Preparing for Production
 

--- a/docs/guides/google-pay/accept-payments.mdx
+++ b/docs/guides/google-pay/accept-payments.mdx
@@ -318,6 +318,10 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
   </TabItem>
 
   <TabItem value="stripe" label="Stripe">
+    <Alert>
+      You may need to ask Stripe to enable Google Pay for your account.
+    </Alert>
+    Please note that Stripe does not recognize network token parameters on creation of a payment methods.
 
     ```shell showlineNumbers title="Charge Payment method through a Proxy"
   curl 'https://api.basistheory.com/proxy'
@@ -338,14 +342,21 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
     -d "payment_method_data[card][last4]"={{token_intent: <TOKEN_INTENT_ID> | json: '$.data.number' | last4 }} \
     -d "payment_method_data[card][network_token][number]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data.number\" }} \
     -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
-    -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
-    -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+    -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }}
     // highlight-end
     ```
 
-    You may need to ask Stripe to enable Google Pay for your account.
+You may notice that in this example we are not passing in any 3DS cryptogram or eci indicator. This is not necessary for charging FPANs. If you need to charge a DPAN, you will need to pass in the 3DS cryptogram and eci indicator available on the `authentication` property of the Token Intent.
 
-    Please note that Stripe does not recognize network token parameters on creation of a payment methods.
+```shell showLineNumbers title="Create a payment transaction for a DPAN"
+  curl 'https://api.basistheory.com/proxy'
+    ...
+    -d "payment_method_data[card][network_token][tokenization_method]"=google_pay \
+    // highlight-start
+    -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+    -d "payment_method_options[card][network_token][electronic_commerce_indicator]"={{token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.eci_indicator\" }}
+    // highlight-end
+```
 
     </TabItem>
 </Tabs>

--- a/docs/guides/google-pay/accept-payments.mdx
+++ b/docs/guides/google-pay/accept-payments.mdx
@@ -350,7 +350,7 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
     </TabItem>
 </Tabs>
 
-<Alert>You are not restricted to only using Checkout. You can use any payment processor that accepts Google Pay tokens.</Alert>
+<Alert>You are not restricted to only using Checkout or Stripe. You can use any payment processor that accepts Google Pay tokens.</Alert>
 
 ## Preparing for Production
 

--- a/docs/guides/google-pay/accept-payments.mdx
+++ b/docs/guides/google-pay/accept-payments.mdx
@@ -316,6 +316,36 @@ You may notice that in this example we are not passing in any 3DS cryptogram or 
 }
 ```
   </TabItem>
+
+  <TabItem value="stripe" label="Stripe">
+
+    ```shell showlineNumbers title="Charge Payment method through a Proxy"
+  curl 'https://api.basistheory.com/proxy'
+    // highlight-start
+    -H 'BT-API-KEY: <PRIVATE_API_KEY>' \
+    -H 'BT-PROXY-URL: https://api.stripe.com/v1/payment_intents' \
+    -H 'Authorization: Bearer <STRIPE_AUTH_TOKEN>' \
+    // highlight-end
+    -d amount=1000 \
+    -d currency=usd \
+    -d "payment_method_types[]"=card \
+    -d confirm=true \
+    -d "payment_method_data[type]"=card \
+    -d "payment_method_data[card][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
+    -d "payment_method_data[card][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
+    -d "payment_method_data[card][last4]"={{token_intent: <TOKEN_INTENT_ID> | json: '$.data.number' | last4 }} \
+    -d "payment_method_data[card][network_token][number]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data.number\" }} \
+    -d "payment_method_data[card][network_token][exp_month]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"MM\" }} \
+    -d "payment_method_data[card][network_token][exp_year]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.data\" | card_exp: \"YYYY\" }} \
+    -d "payment_method_data[card][network_token][tokenization_method]"=google_pay \
+    -d "payment_method_options[card][network_token][cryptogram]"={{ token_intent: <TOKEN_INTENT_ID> | json: \"$.authentication.threeds_cryptogram\" }} \
+    ```
+
+    You may need to ask Stripe to enable Google Pay for your account.
+
+    Please note that Stripe does not recognize network token parameters on creation of a payment methods.
+
+    </TabItem>
 </Tabs>
 
 <Alert>You are not restricted to only using Checkout. You can use any payment processor that accepts Google Pay tokens.</Alert>


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds curl examples for Stripe in Apple Pay and Google Pay guides.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):


<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
