### PR TITLE
fix: updating token expiration date format

### DIFF
--- a/docs/api/tokens/tokens.mdx
+++ b/docs/api/tokens/tokens.mdx
@@ -748,66 +748,66 @@ Returns [an error](/docs/api/errors) if the token failed to delete.
 | `mask`                   | _any_                  | An [expression](/docs/expressions/masks) defining the mask to apply when retrieving token data with restricted permissions.                                                                                              |
 | `enrichments`            | _object_               | _Only available when detokenizing and with expressions._<br /><br /> An object containing the enrichments applied to this token. See [Token Enrichments](/docs/api/tokens/token-enrichments) for available enrichements. |
 | `enrichments`
-| `card`                   | _object_               | _Only available when token type is `card` or `card_number`_<br /><br /> An object containing the card data. See [Card Details](#card-details) for more information.                                                      |	
-| `bank`                   | _object_               | The [Bank Details](#bank-details) when `type` is `bank`, otherwise `null`.                                                                                                                                               |	
-| `network_token`          | _object_               | _Only available when token type is `network_token`_<br /><br /> An object containing the card data. See [Card Details](#card-details) for more information.                                                              |	
-| `fingerprint`            | _string_               | Uniquely identifies the contents of this token. See [Token Types](/docs/api/tokens/token-types) for the default expression for each token type.                                                                          |	
-| `containers`             | _array_                | Array of containers to place this token within. Each container is a path representing a logical grouping of tokens. See [Token Containers](/docs/concepts/what-are-containers/) for details.                             |	
-| `metadata`               | _map\<string, string>_ | A key-value map of strings containing non-sensitive data.                                                                                                                                                                |	
-| `search_indexes`         | _array_                | (Optional) Array of search index [expressions](/docs/expressions/search-indexes) used when creating the token.                                                                                                           |	
-| `fingerprint_expression` | _string_               | (Optional) An [expression](/docs/expressions/fingerprints) defining the value to fingerprint when creating the token.                                                                                                    |	
-| `expires_at`             | _string_               | (Optional) The [token expiration](/docs/api/tokens/#token-expiration) date.                                                                                                                                              |	
-| `created_by`             | _uuid_                 | The [Application](/docs/api/applications#application-object) ID which created the token                                                                                                                                  |	
-| `created_at`             | _date_                 | Created date of the token in ISO 8601 format                                                                                                                                                                             |	
-| `modified_by`            | _uuid_                 | (Optional) The [Application](/docs/api/applications) ID which last modified the token                                                                                                                                    |	
-| `modified_at`            | _date_                 | (Optional) Last modified date of the token in ISO 8601 format                                                                                                                                                            |	
-| `_extras`                | _object_               | (Response-Only) An [object](#extras-object) containing information regarding the tokenization process                                                                                                                    |	
+| `card`                   | _object_               | _Only available when token type is `card` or `card_number`_<br /><br /> An object containing the card data. See [Card Details](#card-details) for more information.                                                      |
+| `bank`                   | _object_               | The [Bank Details](#bank-details) when `type` is `bank`, otherwise `null`.                                                                                                                                               |
+| `network_token`          | _object_               | _Only available when token type is `network_token`_<br /><br /> An object containing the card data. See [Card Details](#card-details) for more information.                                                              |
+| `fingerprint`            | _string_               | Uniquely identifies the contents of this token. See [Token Types](/docs/api/tokens/token-types) for the default expression for each token type.                                                                          |
+| `containers`             | _array_                | Array of containers to place this token within. Each container is a path representing a logical grouping of tokens. See [Token Containers](/docs/concepts/what-are-containers/) for details.                             |
+| `metadata`               | _map\<string, string>_ | A key-value map of strings containing non-sensitive data.                                                                                                                                                                |
+| `search_indexes`         | _array_                | (Optional) Array of search index [expressions](/docs/expressions/search-indexes) used when creating the token.                                                                                                           |
+| `fingerprint_expression` | _string_               | (Optional) An [expression](/docs/expressions/fingerprints) defining the value to fingerprint when creating the token.                                                                                                    |
+| `expires_at`             | _string_               | (Optional) The [token expiration](/docs/api/tokens/#token-expiration) date.                                                                                                                                              |
+| `created_by`             | _uuid_                 | The [Application](/docs/api/applications#application-object) ID which created the token                                                                                                                                  |
+| `created_at`             | _date_                 | Created date of the token in ISO 8601 format                                                                                                                                                                             |
+| `modified_by`            | _uuid_                 | (Optional) The [Application](/docs/api/applications) ID which last modified the token                                                                                                                                    |
+| `modified_at`            | _date_                 | (Optional) Last modified date of the token in ISO 8601 format                                                                                                                                                            |
+| `_extras`                | _object_               | (Response-Only) An [object](#extras-object) containing information regarding the tokenization process                                                                                                                    |
 
-### Extras Object	
+### Extras Object
 
-| Attribute | Type | Description |	
-| --------- | ---- | ------------|	
-| `deduplicated` | boolean | Indicates if the token was [deduplicated](/docs/concepts/what-are-tokens#deduplication) during tokenization |	
-| `deduplication_behavior` | string | Indicates the behavior of the deduplication process, either `read_existing` or `update_existing`. See [Deduplication Behavior](/docs/concepts/what-are-tokens#deduplication) for more information. |	
+| Attribute | Type | Description |
+| --------- | ---- | ------------|
+| `deduplicated` | boolean | Indicates if the token was [deduplicated](/docs/concepts/what-are-tokens#deduplication) during tokenization |
+| `deduplication_behavior` | string | Indicates the behavior of the deduplication process, either `read_existing` or `update_existing`. See [Deduplication Behavior](/docs/concepts/what-are-tokens#deduplication) for more information. |
 
-<CardDetails/>	
-<BankDetails/>	
+<CardDetails/>
+<BankDetails/>
 
-### Token Data Validations	
+### Token Data Validations
 
-#### Bank Object	
+#### Bank Object
 
-| Attribute        | Required | Type     | Default | Description                                               |	
-| ---------------- | -------- | -------- | ------- | --------------------------------------------------------- |	
-| `routing_number` | true     | _string_ | `null`  | Nine-digit ABA routing number. Its checksum is validated. |	
-| `account_number` | true     | _string_ | `null`  | Account number up to seventeen-digits                     |	
+| Attribute        | Required | Type     | Default | Description                                               |
+| ---------------- | -------- | -------- | ------- | --------------------------------------------------------- |
+| `routing_number` | true     | _string_ | `null`  | Nine-digit ABA routing number. Its checksum is validated. |
+| `account_number` | true     | _string_ | `null`  | Account number up to seventeen-digits                     |
 
-#### Card Object	
+#### Card Object
 
-| Attribute          | Required | Type      | Default | Description                                                          |	
-| ------------------ | -------- | --------- | ------- | -------------------------------------------------------------------- |	
-| `number`           | true     | _string_  | `null`  | The card number without any separators                               |	
-| `expiration_month` | false    | _integer_ | `null`  | Number representing the card's expiration month                      |	
-| `expiration_year`  | false    | _integer_ | `null`  | Number representing the card's expiration year                       |	
-| `cvc`              | false    | _string_  | `null`  | Three or four-digit card verification code with automatic expiration |	
+| Attribute          | Required | Type      | Default | Description                                                          |
+| ------------------ | -------- | --------- | ------- | -------------------------------------------------------------------- |
+| `number`           | true     | _string_  | `null`  | The card number without any separators                               |
+| `expiration_month` | false    | _integer_ | `null`  | Number representing the card's expiration month                      |
+| `expiration_year`  | false    | _integer_ | `null`  | Number representing the card's expiration year                       |
+| `cvc`              | false    | _string_  | `null`  | Three or four-digit card verification code with automatic expiration |
 
-See [Test Card Numbers](/docs/api/testing#card-numbers) for suggested test data when using cards.	
+See [Test Card Numbers](/docs/api/testing#card-numbers) for suggested test data when using cards.
 
-The `cvc` property automatically expires and is deleted based on your [CVC Retention Quota](/docs/api/rate-limits#default-quotas), with a default of one hour in order to comply with PCI requirements.	
+The `cvc` property automatically expires and is deleted based on your [CVC Retention Quota](/docs/api/rate-limits#default-quotas), with a default of one hour in order to comply with PCI requirements.
 
 
-<CvcTtlInfoAlert />	
+<CvcTtlInfoAlert />
 
-### Token Expiration	
+### Token Expiration
 
-By default a created token will not expire, however, users can optionally set the `expires_at` property with an ISO8601 `DateTime` when creating a token to determine its expiration date.	
-An expired token is **deleted** from the tenant up to **1 hour** after its expiration time.	
+By default a created token will not expire, however, users can optionally set the `expires_at` property with an ISO8601 `DateTime` when creating a token to determine its expiration date.
+An expired token is **deleted** from the tenant up to **1 hour** after its expiration time.
 
-### Expiration Date Formats	
+### Expiration Date Formats
 
-| Format                      | Example                     |	
-| --------------------------- | --------------------------- |	
-| `DateTime` String w/ Offset | 8/26/2030 7:23:57 PM -07:00 |	
-| `ShortDate` String          | 9/27/2030                   |	
+| Format              | Example                   |
+| ------------------- | ------------------------- |
+| ISO8601 in UTC      | 2030-04-23T13:24:28Z      |
+| ISO8601 with offset | 2030-04-23T17:24:28-04:00 |
 
 <Alert>If an offset is not provided with the <code>DateTime</code> string, it's considered that the provided time is in <b>UTC</b>. When using the <code>ShortDate</code> format, the expiration time will be set as <b>12AM UTC</b>.</Alert>


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- updating token expiration date format; while short dates and non-standard formats are supported by the API, they are non-standard. We should only be documenting usage of standard ISO 8601 formatted dates

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
