### PR TITLE
Fix: Web-elements JS in config page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,4 @@
-// @ts-check
+  // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 import fs from "node:fs";
 import path from "node:path";
@@ -153,7 +153,7 @@ const config = {
       {
         redirects: [
           { from: "/api-reference", to: "/docs/api" },
-          { from: "/elements", to: "/docs/sdks/web/javascript" },
+          { from: "/elements", to: "/docs/sdks/web/web-elements" },
           { from: "/expressions", to: "/docs/expressions" },
           { from: "/labs", to: "/docs" },
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,4 @@
-  // @ts-check
+// @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 import fs from "node:fs";
 import path from "node:path";


### PR DESCRIPTION
https://developers.basistheory.com/docs/concepts/elements#elements-sdks
Clicking on the JS takes me to: https://developers.basistheory.com/docs/sdks/web/javascript
It should take me to: https://developers.basistheory.com/docs/sdks/web/web-elements/

<!-- Describe your changes in detail -->
## Description

-

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
